### PR TITLE
Improve installation procedure

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ CONDA_HOME="$1/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 
 if [ ! -e "$ROOT/conda_runtime.txt" ]; then
-	MINICONDA_FILE="Miniconda-latest-Linux-x86_64.sh"
+	MINICONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
 else
 	MINICONDA_FILE=$(cat "$ROOT/conda_runtime.txt")
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ CACHE=$2
 
 BASH=$(which bash)
 WGET=$(which wget)
-CONDA_HOME="$HOME/.conda"
+CONDA_HOME="$HOME/app/.conda"
 CONDA="$CONDA_HOME/bin/conda"
 PIP="$CONDA_HOME/bin/pip"
 CONDA_STAGING="$1/.conda"

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,7 @@ if [ ! -e $MINICONDA_CACHE ] ; then
 	chmod +x $MINICONDA_CACHE
 fi
 if [ -e $CONDA_HOME ]; then rm -rf $CONDA_HOME; fi
+echo Installing anaconda to $CONDA_HOME
 $MINICONDA_CACHE -b -p $CONDA_HOME #&> /dev/null
 $CONDA_BIN/conda update --yes --quiet --all #&> /dev/null
 $CONDA_BIN/conda install --yes --quiet pip #&> /dev/null

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ CACHE=$2
 
 BASH=$(which bash)
 WGET=$(which wget)
-CONDA_HOME="/home/vcap/app/.conda"
+CONDA_HOME="$HOME/.conda"
 CONDA="$CONDA_HOME/bin/conda"
 PIP="$CONDA_HOME/bin/pip"
 CONDA_STAGING="$1/.conda"

--- a/bin/compile
+++ b/bin/compile
@@ -20,7 +20,7 @@ CACHE=$2
 
 BASH=$(which bash)
 WGET=$(which wget)
-CONDA_HOME="$1/.conda"
+CONDA_HOME="/home/vcap/app/.conda"
 CONDA_BIN="$CONDA_HOME/bin"
 
 if [ ! -e "$ROOT/conda_runtime.txt" ]; then
@@ -63,5 +63,8 @@ echo "---> conda list"
 $CONDA_BIN/conda list
 echo "---> pip list"
 $CONDA_BIN/pip list
+
+echo "-----> Copy to staging area"
+cp -r $CONDA_HOME/* "$1/.conda"
 
 echo "-----> Finished compile step"

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,9 @@ CACHE=$2
 BASH=$(which bash)
 WGET=$(which wget)
 CONDA_HOME="/home/vcap/app/.conda"
-CONDA_BIN="$CONDA_HOME/bin"
+CONDA="$CONDA_HOME/bin/conda"
+PIP="$CONDA_HOME/bin/pip"
+CONDA_STAGING="$1/.conda"
 
 if [ ! -e "$ROOT/conda_runtime.txt" ]; then
 	MINICONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
@@ -41,33 +43,32 @@ fi
 if [ -e $CONDA_HOME ]; then rm -rf $CONDA_HOME; fi
 echo Installing anaconda to $CONDA_HOME
 $MINICONDA_CACHE -b -p $CONDA_HOME #&> /dev/null
-$CONDA_BIN/conda update --yes --quiet --all #&> /dev/null
-$CONDA_BIN/conda install --yes --quiet pip #&> /dev/null
+$CONDA update --yes --quiet --all #&> /dev/null
+$CONDA install --yes --quiet pip #&> /dev/null
 
 echo "-----> Installing Dependencies..."
-$CONDA_BIN/conda install --yes --quiet ipython-notebook #&> /dev/null
+$CONDA install --yes --quiet ipython-notebook #&> /dev/null
 if [ -e "$ROOT/requirements.txt" ]; then
     echo "-----> Installing additional requirements using conda..."
 	while read p; do 
-	    $CONDA_BIN/conda install --yes --quiet $p #&> /dev/null
+	    $CONDA install --yes --quiet $p #&> /dev/null
 	done <"$ROOT/requirements.txt"
     echo "-----> Installing additional requirements using pip..."
-	$CONDA_BIN/pip install -r "$ROOT/requirements.txt"
+	$PIP install -r "$ROOT/requirements.txt"
 fi
 
 echo "-----> Cleaning Python Environment..."
-$CONDA_BIN/conda clean --yes --tarballs
+$CONDA clean --yes --tarballs
 
 echo "-----> Listing Python Environment Information..."
 echo "---> conda list"
-$CONDA_BIN/conda list
+$CONDA list
 echo "---> pip list"
-$CONDA_BIN/pip list
+$PIP list
 
 echo "-----> Copy to staging area"
-CONDA_TARGET="$1/.conda"
-if [ -e $CONDA_TARGET ]; then rm -rf $CONDA_TARGET; fi
-mkdir -p $CONDA_TARGET
-cp -r $CONDA_HOME/* $CONDA_TARGET/
+if [ -e $CONDA_STAGING ]; then rm -rf $CONDA_STAGING; fi
+mkdir -p $CONDA_STAGING
+cp -r $CONDA_HOME/* $CONDA_STAGING/
 
 echo "-----> Finished compile step"

--- a/bin/compile
+++ b/bin/compile
@@ -69,6 +69,6 @@ $PIP list
 echo "-----> Copy to staging area"
 if [ -e $CONDA_STAGING ]; then rm -rf $CONDA_STAGING; fi
 mkdir -p $CONDA_STAGING
-cp -al $CONDA_HOME $CONDA_STAGING
+cp -al $CONDA_HOME/* $CONDA_STAGING/
 
 echo "-----> Finished compile step"

--- a/bin/compile
+++ b/bin/compile
@@ -67,6 +67,7 @@ $CONDA_BIN/pip list
 echo "-----> Copy to staging area"
 CONDA_TARGET="$1/.conda"
 if [ -e $CONDA_TARGET ]; then rm -rf $CONDA_TARGET; fi
-cp -r $CONDA_HOME/* $CONDA_TARGET
+mkdir -p $CONDA_TARGET
+cp -r $CONDA_HOME/* $CONDA_TARGET/
 
 echo "-----> Finished compile step"

--- a/bin/compile
+++ b/bin/compile
@@ -40,9 +40,9 @@ if [ ! -e $MINICONDA_CACHE ] ; then
 fi
 if [ -e $CONDA_HOME ]; then rm -rf $CONDA_HOME; fi
 $MINICONDA_CACHE -b -p $CONDA_HOME #&> /dev/null
+$CONDA_BIN/conda update --yes --quiet --all #&> /dev/null
 
 echo "-----> Installing Dependencies..."
-$CONDA_BIN/conda update --yes --quiet conda #&> /dev/null
 $CONDA_BIN/conda install --yes --quiet pip ipython-notebook #&> /dev/null
 if [ -e "$ROOT/requirements.txt" ]; then
     echo "-----> Installing additional requirements using conda..."
@@ -52,6 +52,11 @@ if [ -e "$ROOT/requirements.txt" ]; then
     echo "-----> Installing additional requirements using pip..."
 	$CONDA_BIN/pip install -r "$ROOT/requirements.txt"
 fi
+
+echo "-----> Cleaning Python Environment..."
+$CONDA_BIN/conda clean --tarballs
+$CONDA_BIN/conda clean --packages
+
 #
 echo "-----> Changing hardcoded paths..."
 grep -rlI $ROOT . | xargs sed -i.bak "s|$ROOT|.|g"

--- a/bin/compile
+++ b/bin/compile
@@ -57,6 +57,12 @@ fi
 echo "-----> Cleaning Python Environment..."
 $CONDA_BIN/conda clean --yes --tarballs
 
+echo "-----> Listing Python Environment Information..."
+echo "---> conda list"
+$CONDA_BIN/conda list
+echo "---> pip list"
+$CONDA_BIN/pip list
+
 #
 echo "-----> Changing hardcoded paths..."
 grep -rlI $ROOT . | xargs sed -i.bak "s|$ROOT|.|g"

--- a/bin/compile
+++ b/bin/compile
@@ -41,9 +41,10 @@ fi
 if [ -e $CONDA_HOME ]; then rm -rf $CONDA_HOME; fi
 $MINICONDA_CACHE -b -p $CONDA_HOME #&> /dev/null
 $CONDA_BIN/conda update --yes --quiet --all #&> /dev/null
+$CONDA_BIN/conda install --yes --quiet pip #&> /dev/null
 
 echo "-----> Installing Dependencies..."
-$CONDA_BIN/conda install --yes --quiet pip ipython-notebook #&> /dev/null
+$CONDA_BIN/conda install --yes --quiet ipython-notebook #&> /dev/null
 if [ -e "$ROOT/requirements.txt" ]; then
     echo "-----> Installing additional requirements using conda..."
 	while read p; do 
@@ -54,8 +55,7 @@ if [ -e "$ROOT/requirements.txt" ]; then
 fi
 
 echo "-----> Cleaning Python Environment..."
-$CONDA_BIN/conda clean --tarballs
-$CONDA_BIN/conda clean --packages
+$CONDA_BIN/conda clean --yes --tarballs
 
 #
 echo "-----> Changing hardcoded paths..."

--- a/bin/compile
+++ b/bin/compile
@@ -69,6 +69,6 @@ $PIP list
 echo "-----> Copy to staging area"
 if [ -e $CONDA_STAGING ]; then rm -rf $CONDA_STAGING; fi
 mkdir -p $CONDA_STAGING
-cp -r $CONDA_HOME/* $CONDA_STAGING/
+cp -al $CONDA_HOME $CONDA_STAGING
 
 echo "-----> Finished compile step"

--- a/bin/compile
+++ b/bin/compile
@@ -65,6 +65,8 @@ echo "---> pip list"
 $CONDA_BIN/pip list
 
 echo "-----> Copy to staging area"
-cp -r $CONDA_HOME/* "$1/.conda"
+CONDA_TARGET="$1/.conda"
+if [ -e $CONDA_TARGET ]; then rm -rf $CONDA_TARGET; fi
+cp -r $CONDA_HOME/* $CONDA_TARGET
 
 echo "-----> Finished compile step"

--- a/bin/compile
+++ b/bin/compile
@@ -63,13 +63,4 @@ $CONDA_BIN/conda list
 echo "---> pip list"
 $CONDA_BIN/pip list
 
-#
-echo "-----> Changing hardcoded paths..."
-grep -rlI $ROOT . | xargs sed -i.bak "s|$ROOT|.|g"
-#
-if [ -e "$ROOT/additional_notebook_config.py" ]
-then
-	echo "-----> Additional IPython configuration file detected"
-fi
-
 echo "-----> Finished compile step"

--- a/bin/detect
+++ b/bin/detect
@@ -16,7 +16,7 @@
 #
 ROOT=$1
 
-HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
+HAS_FILES=$(find $ROOT -depth 1 -name \*.ipynb | wc -l)
 
 if [ "$HAS_FILES" -gt "0" ]; then
 	echo "ipython-notebook"

--- a/bin/detect
+++ b/bin/detect
@@ -14,13 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ROOT=$1
-
-HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
-
-if [ "$HAS_FILES" -gt "0" ]; then
-	echo "ipython-notebook"
-	exit 0
-else
-	exit 1
-fi
+exit 0

--- a/bin/detect
+++ b/bin/detect
@@ -16,8 +16,6 @@
 #
 ROOT=$1
 
-echo "#### find $ROOT -depth 1 -name '*.ipynb' | wc -l"
-
 HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
 
 if [ "$HAS_FILES" -gt "0" ]; then

--- a/bin/detect
+++ b/bin/detect
@@ -14,4 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-exit 0
+ROOT=$1
+
+HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
+
+if [ "$HAS_FILES" -gt "0" ]; then
+	echo "ipython-notebook"
+	exit 0
+else
+	exit 1
+fi

--- a/bin/detect
+++ b/bin/detect
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ROOT=/home/vcap/app
+ROOT=$1
 
 HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
 

--- a/bin/detect
+++ b/bin/detect
@@ -16,7 +16,7 @@
 #
 ROOT=$1
 
-HAS_FILES=$(find $ROOT -depth 1 -name \*.ipynb | wc -l)
+HAS_FILES=$(find "$ROOT" -depth 1 -name \*.ipynb | wc -l)
 
 if [ "$HAS_FILES" -gt "0" ]; then
 	echo "ipython-notebook"

--- a/bin/detect
+++ b/bin/detect
@@ -16,6 +16,8 @@
 #
 ROOT=$1
 
+echo "#### find $ROOT -depth 1 -name '*.ipynb' | wc -l"
+
 HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
 
 if [ "$HAS_FILES" -gt "0" ]; then

--- a/bin/detect
+++ b/bin/detect
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ROOT=$1
+ROOT=/home/vcap/app
 
 HAS_FILES=$(find $ROOT -depth 1 -name '*.ipynb' | wc -l)
 

--- a/bin/release
+++ b/bin/release
@@ -16,10 +16,10 @@
 #
 if [ -e "$1/additional_notebook_config.py" ]
 then
-    with_config="--config=/home/vcap/additional_notebook_config.py"
+    with_config="--config=/home/vcap/app/additional_notebook_config.py"
 fi
 
 echo "
 default_process_types:
-  web: /home/vcap/.conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
+  web: /home/vcap/app/.conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
 "

--- a/bin/release
+++ b/bin/release
@@ -14,12 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+CONDA_HOME="$1/.conda"
+
 if [ -e "$1/additional_notebook_config.py" ]
 then
-    with_config="--config=/home/vcap/app/additional_notebook_config.py"
+    with_config="--config=$1/additional_notebook_config.py"
 fi
 
 echo "
 default_process_types:
-  web: /home/vcap/app/.conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
+  web: $CONDA_HOME/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
 "

--- a/bin/release
+++ b/bin/release
@@ -16,10 +16,10 @@
 #
 if [ -e "$1/additional_notebook_config.py" ]
 then
-    with_config="--config=./additional_notebook_config.py"
+    with_config="--config=/home/vcap/additional_notebook_config.py"
 fi
 
 echo "
 default_process_types:
-  web: ./.conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
+  web: /home/vcap/.conda/bin/ipython notebook --no-browser --no-mathjax --ip=* --port \$PORT $with_config
 "

--- a/bin/release
+++ b/bin/release
@@ -15,11 +15,12 @@
 # limitations under the License.
 #
 
-CONDA_HOME="$1/.conda"
+ROOT="/home/vcap/app"
+CONDA_HOME="$ROOT/.conda"
 
-if [ -e "$1/additional_notebook_config.py" ]
+if [ -e "$ROOT/additional_notebook_config.py" ]
 then
-    with_config="--config=$1/additional_notebook_config.py"
+    with_config="--config=$ROOT/additional_notebook_config.py"
 fi
 
 echo "


### PR DESCRIPTION
compile:
-Use Miniconda3 as default
-Install to $HOME/app/.conda and copy to staging
   -avoid path changes later
-Clean tarballs to reduce droplet size
-Prepare for ipython-buildpack

detect:
-Change escaping

release:
-Remove relative paths